### PR TITLE
Add userId to Serie model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ packages/client/build/
 # Environment
 .env
 .env.local
+.envrc
 packages/server/.env
 
 # Package manager

--- a/packages/model/src/metamodel/Serie.metamodel.ts
+++ b/packages/model/src/metamodel/Serie.metamodel.ts
@@ -5,7 +5,8 @@ export interface ISerieDao {
     weight: number,
     createdAt?: string;
     updatedAt?: string;
-    restTime?: number
+    restTime?: number;
+    userId?: string;
 }
 
 
@@ -14,7 +15,8 @@ export interface ISerie {
     createdAt?: string,
     reps: number,
     weight: number,
-    restTime?: number
+    restTime?: number;
+    userId?: string;
 }
 
 export interface ISerieUpdate {

--- a/packages/server/src/api/mongoose/serie.mongoose.ts
+++ b/packages/server/src/api/mongoose/serie.mongoose.ts
@@ -10,7 +10,8 @@ const schema = new Schema(
     {
         reps: Number,
         weight: Number,
-        restTime: Number
+        restTime: Number,
+        userId: String
       },
       {
         timestamps: true,

--- a/packages/server/src/api/routers/serie.router.ts
+++ b/packages/server/src/api/routers/serie.router.ts
@@ -1,15 +1,16 @@
 import { ISerie, IExercise, ISerieUpdate } from "balanced-gym-model";
 import SerieService from "../services/serie.service";
 import ExerciseService from "../services/exercise.service";
-import { Request, Response, NextFunction } from "express";
+import { Response, NextFunction } from "express";
 import * as HttpStatus from "http-status-codes";
 import express from "express";
+import { AuthenticatedRequest } from "../middleware/auth.middleware";
 
 const api = express.Router();
 
 api.patch(
   "/updateSerie/:serieId/exercise/:exerciseId",
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const { serieId, exerciseId } = req.params;
       const serieUpdate: ISerieUpdate = req.body;
@@ -26,7 +27,7 @@ api.patch(
 
 api.delete(
   "/deleteSerie/:serieId/exercise/:exerciseId",
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const { serieId, exerciseId } = req.params;
       const updatedSerie: ISerie = await SerieService.deleteSerie(serieId);
@@ -42,11 +43,11 @@ api.delete(
 
 api.post(
   "/newSerie/:exerciseId",
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const { exerciseId } = req.params;
       const serieUpdate: ISerieUpdate = req.body;
-      const newSerie: ISerie = await SerieService.newSerie(exerciseId, serieUpdate);
+      const newSerie: ISerie = await SerieService.newSerie(exerciseId, serieUpdate, req.userId);
       const exercise: IExercise = await ExerciseService.getExerciseById(
         exerciseId
       );

--- a/packages/server/src/api/services/serie.service.ts
+++ b/packages/server/src/api/services/serie.service.ts
@@ -21,17 +21,19 @@ export class SerieService {
       reps: serieDao.reps,
       weight: serieDao.weight,
       createdAt: serieDao.createdAt,
-      restTime: serieDao.restTime
+      restTime: serieDao.restTime,
+      userId: serieDao.userId
     };
     return serie;
   }
   async newSerie(
     exerciseId: string,
-    suggestedSerie: ISerieUpdate = { reps: 10, weight: 1 }
+    suggestedSerie: ISerieUpdate = { reps: 10, weight: 1 },
+    userId?: string
   ): Promise<ISerie> {
     L.info(`creating serie for exercise id ${exerciseId}`);
     const serieDao: ISerieDao = await new SerieDocumentModel(
-      suggestedSerie
+      { ...suggestedSerie, userId }
     ).save();
     const exerciseDao: IExerciseDocument = await ExerciseDocumentModel.findById(exerciseId).exec();
     exerciseDao.series.push(serieDao);
@@ -42,7 +44,8 @@ export class SerieService {
       reps: serieDao.reps,
       weight: serieDao.weight,
       createdAt: serieDao.createdAt,
-      restTime: serieDao.restTime
+      restTime: serieDao.restTime,
+      userId: serieDao.userId
     };
     return serie;
   }
@@ -60,7 +63,8 @@ export class SerieService {
       reps: serieDao.reps,
       weight: serieDao.weight,
       createdAt: serieDao.createdAt,
-      restTime: serieDao.restTime
+      restTime: serieDao.restTime,
+      userId: serieDao.userId
     };
     return serie;
   }

--- a/packages/server/src/scripts/backfill-serie-userid.ts
+++ b/packages/server/src/scripts/backfill-serie-userid.ts
@@ -1,0 +1,46 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import * as admin from 'firebase-admin';
+import mongoose from 'mongoose';
+import { SerieDocumentModel } from '../api/mongoose/serie.mongoose';
+
+admin.initializeApp({
+  credential: admin.credential.cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+  }),
+});
+
+async function backfillSerieUserId() {
+  const email = 'papesce@gmail.com';
+
+  const userRecord = await admin.auth().getUserByEmail(email);
+  const userId = userRecord.uid;
+  console.log(`Found user: ${email} (uid: ${userId})`);
+
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    console.error('MONGO_URI not set in .env');
+    process.exit(1);
+  }
+
+  await mongoose.connect(mongoUri);
+  console.log('Connected to MongoDB');
+
+  const result = await SerieDocumentModel.updateMany(
+    { userId: { $exists: false } },
+    { $set: { userId } }
+  );
+
+  console.log(`Updated ${result.modifiedCount} series with userId: ${userId}`);
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+backfillSerieUserId().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
  - Adds `userId` field to the Serie schema, interfaces, and service layer
  - New series are automatically associated with the authenticated user on creation
  - Includes a backfill script (`backfill-serie-userid.ts`) to assign all existing series to papesce@gmail.com                                                                                               
                                                                                                              
  Closes #66 (partial — serie only, other models to follow)                                                                                                                                                  
                                                           
  ## Test plan
  - [ ] Build passes (`pnpm build` in packages/server)
  - [ ] Run backfill script against the database and verify existing series get the userId
  - [ ] Create a new serie via the API and confirm userId is persisted in MongoDB     

Closes issue #66