### PR TITLE
fixed issues with thee build

### DIFF
--- a/packages/client/build.sh
+++ b/packages/client/build.sh
@@ -5,4 +5,4 @@ mkdir ../server/public;
 cp -a ../server/api-docs/. ../server/public/api-docs;
 cp -a ../server/assets/. ../server/public/assets;
 cd build
-mv * ../../server/public
+cp -a . ../../server/public

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -2,6 +2,7 @@
   "name": "balanced-gym-model",
   "version": "0.4.0",
   "description": "Balanced Gym App Model",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "lib": ["es2020"],
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
1. packages/model/tsconfig.json — changed module from commonjs to ES2020 and added                 
  moduleResolution: "bundler" so Vite/Rollup can resolve named exports like emptySerie               
  2. packages/client/build.sh — changed mv * to cp -a . to handle the case where assets/ already     
  exists in the target      