### PR TITLE
fix deploy port

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,5 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --port 3000 \
-            --set-env-vars PORT=3000 \
             --service-account=${{ secrets.GCP_SERVICE_ACCOUNT }} \
             --project=${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
remove --set-env-vars PORT=3000 — the --port 3000 flag already tells Cloud Run which
  port to use, and PORT is set automatically.