### PR TITLE
revert model to CommonJS and inline emptySerie

### DIFF
--- a/packages/client/src/components/logPage/serieInput/SerieInput.tsx
+++ b/packages/client/src/components/logPage/serieInput/SerieInput.tsx
@@ -3,8 +3,10 @@ import IconButton from '@mui/material/IconButton';
 import DoneIcon from '@mui/icons-material/Done';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-import { ISerie, emptySerie } from 'balanced-gym-model';
+import { ISerie } from 'balanced-gym-model';
 import './SerieInput.css';
+
+const emptySerie: ISerie = { _id: "", createdAt: "", reps: 0, weight: 0 };
 
 interface SerieInputProps {
     initialSerie?: ISerie;

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -2,7 +2,6 @@
   "name": "balanced-gym-model",
   "version": "0.4.0",
   "description": "Balanced Gym App Model",
-  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/model/tsconfig.json
+++ b/packages/model/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "ES2020",
-    "moduleResolution": "bundler",
+    "module": "commonjs",
     "lib": ["es2020"],
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
### Summary
- Reverted model package to CommonJS output (removed `"type": "module"` and restored `"module": "commonjs"` in tsconfig) to fix server startup crash (`ERR_MODULE_NOT_FOUND`)
- Inlined `emptySerie` constant in `SerieInput.tsx` to avoid Rollup failing on named CJS exports during Vite production build

### Context
The ESM change from PR #79 fixed the Vite/Rollup build but broke the server at runtime because the server uses CommonJS `require()`. The root issue is that Rollup cannot resolve named exports from a workspace-linked CommonJS package during production builds. Inlining the single value import (`emptySerie`) sidesteps this while keeping both server and client working.

### Test plan
- [x] Docker build succeeds
- [x] Container starts and responds HTTP 200 on port 3000
- [ ] GitHub Actions deploy completes successfully
