### PR TITLE
Serve admin app at /admin in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/server/package.json ./packages/server/
 COPY packages/client/package.json ./packages/client/
 COPY packages/model/package.json ./packages/model/
+COPY packages/admin/package.json ./packages/admin/
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:server": "pnpm --filter balanced-gym-app-server dev",
     "start": "pnpm --filter balanced-gym-app-server start",
     "types": "pnpm --filter balanced-gym-model types",
-    "build": "pnpm --filter balanced-gym-model types && pnpm --parallel --filter balanced-gym-app-client --filter balanced-gym-app-server run build",
+    "build": "pnpm --filter balanced-gym-model types && pnpm --parallel --filter balanced-gym-app-client --filter balanced-gym-app-admin --filter balanced-gym-app-server run build",
     "build:client": "pnpm --filter balanced-gym-app-client build",
     "build:admin": "pnpm --filter balanced-gym-app-admin build",
     "test:model": "pnpm --filter balanced-gym-model test",

--- a/packages/admin/build.sh
+++ b/packages/admin/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf ../server/public/admin
+mkdir -p ../server/public/admin
+cd build
+cp -a . ../../server/public/admin

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && ./build.sh",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/admin',
   plugins: [react()],
   server: {
     host: '0.0.0.0',

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -47,6 +47,10 @@ export default class ExpressServer {
     http.createServer(app).listen(p, welcome(p));
     mongoose.init();
     const root = path.normalize(__dirname + "/..");
+    app.use("/admin", express.static(`${root}/public/admin`));
+    app.get("/admin/*", (req, res) => {
+      res.sendFile(`${root}/public/admin/index.html`);
+    });
     app.get("/*", (req, res, next) => {
       if (req.url === "/" || req.url === "/spec") return next();
       if (req.url.startsWith("/api")) return next();


### PR DESCRIPTION
## Summary
- Build admin app in the Docker image alongside the client
- Serve it at `/admin` via Express static + SPA catch-all
- Add `base: '/admin'` to admin Vite config for correct asset paths

After deploy, admin will be accessible at `https://balanced-gym-app-2hixzlvwpa-uc.a.run.app/admin`