### PR TITLE
Fix admin routing, mobile layout, and local deploy port

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,31 @@ The server exposes a REST API at `/api/v1` with Swagger documentation available 
 
 ## Deployment
 
-### Docker
+### Local Deploy (Podman)
 
 ```bash
-docker build -t balanced-gym-app .
-docker run -p 3000:3000 balanced-gym-app
+pnpm local-deploy   # Build image and run on localhost:4000
+pnpm local-run      # Run existing image (no rebuild) on localhost:4000
+```
+
+`local-deploy` builds the Docker image with Firebase env vars baked in, removes any previous container/image, and runs the app in detached mode. `local-run` skips the build and just restarts the container. Both use `packages/server/.env` for runtime environment variables.
+
+Check logs with `podman logs balanced-gym-app`, stop with `podman stop balanced-gym-app`.
+
+### Cloud (Google Cloud Run)
+
+Pushing to `master` triggers a GitHub Actions workflow that builds the Docker image, pushes it to Artifact Registry, and deploys to Cloud Run.
+
+### Docker (manual)
+
+```bash
+docker build \
+  --build-arg VITE_FIREBASE_API_KEY=<key> \
+  --build-arg VITE_FIREBASE_AUTH_DOMAIN=<domain> \
+  --build-arg VITE_FIREBASE_PROJECT_ID=<project> \
+  --build-arg VITE_FIREBASE_APP_ID=<app-id> \
+  -t balanced-gym-app .
+docker run -p 3000:3000 --env-file packages/server/.env balanced-gym-app
 ```
 
 ## License

--- a/local-deploy.sh
+++ b/local-deploy.sh
@@ -2,4 +2,4 @@
 podman stop balanced-gym-app 2>/dev/null
 podman rm balanced-gym-app 2>/dev/null
 podman rmi balanced-gym-app 2>/dev/null
-podman build --build-arg VITE_FIREBASE_API_KEY=AIzaSyBQmkzZeN8uX-fUJRz9-IZgAblFqvsihLA --build-arg VITE_FIREBASE_AUTH_DOMAIN=balanced-life-4a8c7.firebaseapp.com --build-arg VITE_FIREBASE_PROJECT_ID=balanced-life-4a8c7 --build-arg VITE_FIREBASE_APP_ID=1:612571722603:web:da53740b78fbf08f5f122e -t balanced-gym-app . && podman run --rm --name balanced-gym-app -p 3000:3000 --env-file packages/server/.env balanced-gym-app
+podman build --build-arg VITE_FIREBASE_API_KEY=AIzaSyBQmkzZeN8uX-fUJRz9-IZgAblFqvsihLA --build-arg VITE_FIREBASE_AUTH_DOMAIN=balanced-life-4a8c7.firebaseapp.com --build-arg VITE_FIREBASE_PROJECT_ID=balanced-life-4a8c7 --build-arg VITE_FIREBASE_APP_ID=1:612571722603:web:da53740b78fbf08f5f122e -t balanced-gym-app . && podman run -d --rm --name balanced-gym-app -p 4000:3000 --env-file packages/server/.env balanced-gym-app

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+podman stop balanced-gym-app 2>/dev/null
+podman rm balanced-gym-app 2>/dev/null
+podman run -d --rm --name balanced-gym-app -p 4000:3000 --env-file packages/server/.env balanced-gym-app

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "backup": "pnpm --filter balanced-gym-app-server backup",
     "restore": "pnpm --filter balanced-gym-app-server restore",
     "set-admin": "pnpm --filter balanced-gym-app-server set-admin",
-    "local-deploy": "./local-deploy.sh"
+    "local-deploy": "./local-deploy.sh",
+    "local-run": "./local-run.sh"
   },
   "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501",
   "dependencies": {

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
       <CssBaseline />
       <Provider store={store}>
         <AuthProvider>
-          <BrowserRouter>
+          <BrowserRouter basename="/admin">
             <Routes>
               <Route path="/login" element={<Login />} />
               <Route path="/" element={<ProtectedRoute><AdminLayout><ExerciseBrowser /></AdminLayout></ProtectedRoute>} />

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -1,6 +1,5 @@
 body {
-  margin: 0 auto;
-  max-width: 480px;
+  margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
## Summary
- Fix admin app white screen by adding `basename="/admin"` to BrowserRouter
- Remove `max-width: 480px` from client so it fills the screen on mobile
- Change local deploy port from 3000 to 4000 to avoid conflict with dev mode
- Add `pnpm local-run` script to restart container without rebuilding the image

## Test plan
- [x] Run `pnpm local-deploy` and verify app is accessible at localhost:4000
- [x] Navigate to /admin and confirm it loads (no white screen)
- [ ] Open client app on mobile and confirm it stretches to full width
- [x] Run `pnpm local-run` and verify container restarts without rebuilding